### PR TITLE
Feature/data attachment export

### DIFF
--- a/Resources/Views/export-attachments-data.twig
+++ b/Resources/Views/export-attachments-data.twig
@@ -23,15 +23,15 @@
                 <label for="audio_types">Audios</label>
             </div>
             <div class="radio-wrapper">
-                <input class="mimetype-radio" type="radio" id="all_types" name="mimetype" value="all" >
+                <input class="mimetype-radio" type="radio" id="all_types" name="mimetype" value="all">
                 <label for="all_types">Tous les médias</label>
             </div>
         </div>
 
         <h3>Langues</h3>
         <p class="desc">Si vous vous choisissez toutes les langues, les données des images apparaîtront autant de fois que vous avez de langues sur le site</br>
-        Dans le cas d'un export d'images, nous vous conseillons de n'exporter que la langue par défaut du site</br>
-        Pour les autres types de médias, nous vous conseillons un export dans toutes les langues</p>
+            Dans le cas d'un export d'images, nous vous conseillons de n'exporter que la langue par défaut du site</br>
+            Pour les autres types de médias, nous vous conseillons un export dans toutes les langues</p>
         <div class="form-input flex-container">
             <div class="radio-wrapper">
                 <input class="language-radio" type="radio" id="language_default" name="request_language" value="language_default" checked>
@@ -81,22 +81,26 @@
                 <input class="field-checkbox" type="checkbox" id="export_field_lng" name="export_field_lng" value="media_lng" checked>
                 <label for="export_field_lng">Longitude</label>
             </div>
+            <div class="checkbox-wrapper">
+                <input class="field-checkbox" type="checkbox" id="export_field_expired" name="export_field_expired" value="attachment_expire" checked>
+                <label for="export_field_expire">Date d'expiration</label>
+            </div>
         </div>
         <div class="flex-container submit-container">
-        <input type="submit" id="submit_export" class="button button-primary" value="Exporter les données des médias"></input>
-        <strong></small>NB : La création du fichier prend entre 10 et 15 minutes et sa durée de vie est de 24h</small></strong>
+            <input type="submit" id="submit_export" class="button button-primary" value="Exporter les données des médias"></input>
+            <strong></small>NB : La création du fichier prend entre 10 et 15 minutes et sa durée de vie est de 24h</small></strong>
         </div>
     </form>
     <div class="download-files">
         <h2>Fichiers disponibles au téléchargement</h2>
         <div class="files-wrapper">
-        {% if files %}
-            <ul class="files">
-                {% for file in files %}
-                    <li>Exporté le {{ file.created|default }} : <a href="{{ file.url }}" tagret="_blank">{{ file.name }}</a></li>
-                {% endfor %}
-            </ul>
-        {% endif %}
+            {% if files %}
+                <ul class="files">
+                    {% for file in files %}
+                        <li>Exporté le {{ file.created|default }} : <a href="{{ file.url }}" tagret="_blank">{{ file.name }}</a></li>
+                    {% endfor %}
+                </ul>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/Resources/Views/export-attachments-data.twig
+++ b/Resources/Views/export-attachments-data.twig
@@ -46,10 +46,10 @@
         <h3>Champs à faire apparaître dans l'export</h3>
         <div class="form-input flex-container">
             {% if export_fields %}
-                {% for field in export_fields %}
+                {% for value, field in export_fields %}
                     <div class="checkbox-wrapper">
-                        <input class="field-checkbox" type="checkbox" id="export_field_{{ field.name }}" name="export_field_{{ field.name }}" value="{{ field.value }}" checked>
-                        <label for="export_field_expire">{{ field.label }}</label>
+                        <input class="field-checkbox" type="checkbox" id="export_field_{{ field.name }}" name="export_field_{{ field.name }}" value="{{ value }}" checked>
+                        <label for="export_field_{{ field.name }}">{{ field.label }}</label>
                     </div>
                 {% endfor %}
             {% endif %}

--- a/Resources/Views/export-attachments-data.twig
+++ b/Resources/Views/export-attachments-data.twig
@@ -45,46 +45,14 @@
 
         <h3>Champs à faire apparaître dans l'export</h3>
         <div class="form-input flex-container">
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_id" name="export_field_id" value="ID" checked>
-                <label for="export_field_id">Identifiant</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_name" name="export_field_name" value="post_name" checked>
-                <label for="export_field_name">Nom du média</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_title" name="export_field_title" value="post_title" checked>
-                <label for="export_field_title">Titre du média</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_url" name="export_field_url" value="url" checked>
-                <label for="export_field_url">Url du fichier</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_caption" name="export_field_caption" value="post_excerpt" checked>
-                <label for="export_field_caption">Légende</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_author" name="export_field_author" value="media_author" checked>
-                <label for="export_field_author">Auteur</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_rights" name="export_field_rights" value="medias_rights_management" checked>
-                <label for="export_field_rights">Gestion des droits</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_lat" name="export_field_lat" value="media_lat" checked>
-                <label for="export_field_lat">Latitude</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_lng" name="export_field_lng" value="media_lng" checked>
-                <label for="export_field_lng">Longitude</label>
-            </div>
-            <div class="checkbox-wrapper">
-                <input class="field-checkbox" type="checkbox" id="export_field_expired" name="export_field_expired" value="attachment_expire" checked>
-                <label for="export_field_expire">Date d'expiration</label>
-            </div>
+            {% if export_fields %}
+                {% for field in export_fields %}
+                    <div class="checkbox-wrapper">
+                        <input class="field-checkbox" type="checkbox" id="export_field_{{ field.name }}" name="export_field_{{ field.name }}" value="{{ field.value }}" checked>
+                        <label for="export_field_expire">{{ field.label }}</label>
+                    </div>
+                {% endfor %}
+            {% endif %}
         </div>
         <div class="flex-container submit-container">
             <input type="submit" id="submit_export" class="button button-primary" value="Exporter les données des médias"></input>

--- a/Services/AttachmentsDataExport.php
+++ b/Services/AttachmentsDataExport.php
@@ -40,6 +40,10 @@ class AttachmentsDataExport
             );
         }
 
+        // Champs de cochables dans le BO
+        $data['export_fields'] = $this->defineExportFields();
+        $data['export_fields'] = array_merge($data['export_fields']['post_fields'], $data['export_fields']['acf_fields']);
+
         // On récupère la liste  des fichiers d'export encore valides pour afficher les liens de téléchargement
         $data['files'] = dropzone_get('woody_export_attachments_files');
         if (!empty($data['files'])) {
@@ -75,6 +79,7 @@ class AttachmentsDataExport
 
     public function attachmentsDoExport($args)
     {
+        output_log('lancement de la fonction', '');
         output_h1('Do attachments export');
         if ($args['request_args'] && $args['fields']) {
             // On récupère tous les attachments en fonctions des arguments passés(mimetype, lang)
@@ -82,6 +87,7 @@ class AttachmentsDataExport
             $count_posts = 0;
             output_h2('Requesting attachments');
             $query = $this->attachmentsQuery($args['request_args']);
+            output_log($query, 'query');
             output_log(sprintf('0/%s ', $query->found_posts));
 
             // Tant que l'on a pas récupéré la totalité des attachments correspondant à la requête ($query->found_posts),
@@ -98,8 +104,10 @@ class AttachmentsDataExport
 
             // Une fois les attachments récupérés, on convertit le tableau en un fichier csv que l'on stocke dans les uploads du site initiateur
             if (!empty($attachments)) {
+                output_log('there is attachments', '');
                 $time = time();
                 $filespath = $this->arrayToCsv($attachments, $time);
+                output_log($filespath, 'lien du fichier');
                 if ($filespath) {
                     // On réucpère la liste des fichiers existants pour la mettre à jour.
                     // Cette liste nous servira à afficher les liens de téléchargement
@@ -159,8 +167,9 @@ class AttachmentsDataExport
     public function getAttachmentsData($posts, $fields)
     {
         $return = [];
-        $post_fields = ['ID', 'post_name', 'post_title', 'post_excerpt'];
-        $acf_fields = ['media_author', 'medias_rights_management', 'media_lat', 'media_lng', 'attachment_expire'];
+        $custom_fields = $this->defineExportFields();
+        $post_fields = $custom_fields['post_fields'];
+        $acf_fields = $custom_fields['acf_fields'];
 
         if (!empty($posts)) {
             foreach ($posts as $post) {
@@ -238,5 +247,58 @@ class AttachmentsDataExport
         } else {
             dropzone_set('woody_export_attachments_files', $files);
         }
+    }
+
+    public function defineExportFields() {
+        $return = [
+            'post_fields' => [
+                    'ID' => [
+                    'name' => 'id',
+                    'label' => 'Identifiant'
+                ],
+                'post_name' => [
+                    'name' => 'name',
+                    'label' => 'Nom du média'
+                ],
+                'post_title' => [
+                    'name' => 'title',
+                    'label' => 'Titre du média'
+                ],
+                'post_url' => [
+                    'name' => 'url',
+                    'label' => 'Url du fichier'
+                ],
+                'post_excerpt' => [
+                    'name' => 'caption',
+                    'label' => 'Légende'
+                ]
+            ],
+            'acf_fields' => [
+                'media_author' => [
+                    'name' => 'author',
+                    'label' => 'Auteur'
+                ],
+                'medias_rights_management' => [
+                    'name' => 'rights',
+                    'label' => 'Gestion des droits'
+                ],
+                'media_lat' => [
+                    'name' => 'lat',
+                    'label' => 'Latitude'
+                ],
+                'media_lng' => [
+                    'name' => 'lng',
+                    'label' => 'Longitude'
+                ],
+                'attachment_expire' => [
+                    'name' => 'expired',
+                    'label' => 'Date d\'expiration'
+                ]
+            ],
+        ];
+
+        $return = apply_filters('woody_attachments_define_export_datas', $return);
+
+        return $return;
     }
 }

--- a/Services/AttachmentsDataExport.php
+++ b/Services/AttachmentsDataExport.php
@@ -160,7 +160,7 @@ class AttachmentsDataExport
     {
         $return = [];
         $post_fields = ['ID', 'post_name', 'post_title', 'post_excerpt'];
-        $acf_fields = ['media_author', 'medias_rights_management', 'media_lat', 'media_lng'];
+        $acf_fields = ['media_author', 'medias_rights_management', 'media_lat', 'media_lng', 'attachment_expire'];
 
         if (!empty($posts)) {
             foreach ($posts as $post) {

--- a/Services/AttachmentsDataExport.php
+++ b/Services/AttachmentsDataExport.php
@@ -79,7 +79,6 @@ class AttachmentsDataExport
 
     public function attachmentsDoExport($args)
     {
-        output_log('lancement de la fonction', '');
         output_h1('Do attachments export');
         if ($args['request_args'] && $args['fields']) {
             // On récupère tous les attachments en fonctions des arguments passés(mimetype, lang)
@@ -87,7 +86,6 @@ class AttachmentsDataExport
             $count_posts = 0;
             output_h2('Requesting attachments');
             $query = $this->attachmentsQuery($args['request_args']);
-            output_log($query, 'query');
             output_log(sprintf('0/%s ', $query->found_posts));
 
             // Tant que l'on a pas récupéré la totalité des attachments correspondant à la requête ($query->found_posts),
@@ -104,10 +102,8 @@ class AttachmentsDataExport
 
             // Une fois les attachments récupérés, on convertit le tableau en un fichier csv que l'on stocke dans les uploads du site initiateur
             if (!empty($attachments)) {
-                output_log('there is attachments', '');
                 $time = time();
                 $filespath = $this->arrayToCsv($attachments, $time);
-                output_log($filespath, 'lien du fichier');
                 if ($filespath) {
                     // On réucpère la liste des fichiers existants pour la mettre à jour.
                     // Cette liste nous servira à afficher les liens de téléchargement
@@ -171,17 +167,17 @@ class AttachmentsDataExport
         $post_fields = $custom_fields['post_fields'];
         $acf_fields = $custom_fields['acf_fields'];
 
-        if (!empty($posts)) {
+        if (!empty($fields)) {
             foreach ($posts as $post) {
-                foreach ($post_fields as $post_field) {
-                    if (in_array($post_field, $fields)) {
-                        $return[$post->ID][$post_field] = $post->{$post_field};
+                foreach ($post_fields as $key => $post_field) {
+                    if (in_array($key, $fields)) {
+                        $return[$post->ID][$key] = $post->{$key};
                     }
                 }
 
-                foreach ($acf_fields as $acf_field) {
-                    if (in_array($acf_field, $fields)) {
-                        $return[$post->ID][$acf_field] = get_field($acf_field, $post->ID);
+                foreach ($acf_fields as $key => $acf_field) {
+                    if (in_array($key, $fields)) {
+                        $return[$post->ID][$key] = get_field($key, $post->ID);
                     }
                 }
 


### PR DESCRIPTION
Lors d'un export des médias, on peut choisir quel champs on souhaite ou non exporter.

Suite à la [demande de crt-bretagne](https://mantis.raccourci.fr/view.php?id=64820), il est désormais possible d'exporter la date d'expiration d'un media.

Modification : 
- Ajout d'un tableau php hookable contenant les données pour la construction du formulaire.
- Ajout d'un filtre pour modifier les données
- Boucle dans le twig pour afficher les champs cochables

Avant : 
![image](https://github.com/woody-wordpress/woody-lib-attachments/assets/97923256/f7ea759e-a8af-4380-8401-58627de0a8e9)

Après : 
![image](https://github.com/woody-wordpress/woody-lib-attachments/assets/97923256/7b5a91d1-5b8d-4930-afdb-ce11c1c860cb)

Format des données retournées en CSV : 
```csv
ID;post_name;post_title;post_url;post_excerpt;media_author;medias_rights_management;media_lat;media_lng;attachment_expire;dam_ids_ajaris_id
1289307;adlc-2019-marc-bauer_photo_a-mole;"Adlc 2019 Marc Bauer Photo A.mole";;"Art dans les chapelles - 2019 - Marc Bauer";"Photo - Aurelien Mole";"Art dans les chapelles - Droits jusqu'au 28/09/2032";;;2023-11-26;2469547
```